### PR TITLE
Remove abandoned package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
   "require": {
     "php": ">=5.6.0",
     "setasign/fpdi": "^2.0",
-    "setasign/fpdf": "^1.8",
-    "setasign/fpdi-fpdf": "^2.0"
+    "setasign/fpdf": "^1.8"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
As can be seen in the packagist page for `setasign/fpdi-fpdf`, they recommend this package is removed from the composer.json file.